### PR TITLE
Add UIKit import

### DIFF
--- a/OHAlertView/OHAlertView.h
+++ b/OHAlertView/OHAlertView.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @interface OHAlertView : UIAlertView
 


### PR DESCRIPTION
As OHAlertView inherits from UIAlertView, it needs UIKit to be imported to compile. Right now it's made
by putting UIKit into precompiled header for the project. But newer versions of XCode do not create a
precompiled header for the project anymore by default, therefore it won't compile as UIAlertView class is
not defined. Solved the problem by adding "import UIKit" statement in header file itself