### PR TITLE
Remove from NSNotificationCenter observing on dealloc

### DIFF
--- a/OHAlertView/OHAlertView.m
+++ b/OHAlertView/OHAlertView.m
@@ -104,6 +104,15 @@
 	return self;
 }
 
+- (void)dealloc
+{
+    #if USE_UIALERTVIEW == 0
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UITextFieldTextDidChangeNotification
+                                                  object:nil];
+    #endif
+}
+
 -(void)show
 {
 #if USE_UIALERTVIEW


### PR DESCRIPTION
This request removing NotificationCenter observing to avoid crashes on iOS8+ and assure that no observer still alive after OHAlertView deallocation.

Related issue : https://github.com/AliSoftware/OHAlertView/issues/7 
